### PR TITLE
Allow SpikeData.randomized() when spikes alias.

### DIFF
--- a/braingeneers/analysis/analysis.py
+++ b/braingeneers/analysis/analysis.py
@@ -952,7 +952,8 @@ class SpikeData:
         # "randomized spike matrix" to store them in.
         sm = self.sparse_raster(dt)
         if sm.max() > 1:
-            raise ValueError(f'{dt = }ms is to coarse to randomize.')
+            logger.warn(f'Discretizing at {dt = }ms loses some spikes.')
+            sm = sm > 0
 
         idces, times = np.nonzero(randomize_raster(sm, seed))
         return SpikeData(idces, times*dt, length=self.length, N=self.N,


### PR DESCRIPTION
Previously, if you tried to randomize a SpikeData and you ended up
aliasing two spikes into the same bin, it would fail with a ValueError.
But some datasets are ill-formed and include multiple spikes at the same
time, so it's impossible to use this method.

Now only a warning is produced, so it's up to the user to consider
whether that aliasing is enough of a problem.
