### PR TITLE
fix(randomization): sporadic ValueError

### DIFF
--- a/braingeneers/analysis/analysis.py
+++ b/braingeneers/analysis/analysis.py
@@ -1004,7 +1004,6 @@ def randomize_raster(raster, seed=None):
             weights[unit] -= 1
             rsm[unit, bin] += 1
 
-    print(weights)
     return rsm
 
 

--- a/braingeneers/analysis/analysis.py
+++ b/braingeneers/analysis/analysis.py
@@ -954,7 +954,6 @@ class SpikeData:
         sm = self.sparse_raster(dt)
         if sm.max() > 1:
             logger.warn(f'Discretizing at {dt = }ms loses some spikes.')
-            sm = sm > 0
 
         idces, times = np.nonzero(randomize_raster(sm, seed))
         return SpikeData(idces, times*dt, length=self.length, N=self.N,


### PR DESCRIPTION
In `randomize_raster()`, when new units are being selected to provide
the spikes for a given bin, previously sampling without replacement was
used. This meant that sometimes there would not be enough units left to
create a random sample, resulting in a ValueError.

This commit replaces this approach with a new method called
`best_effort_sample()`, which attempts to approximate sampling without
replacement as closely as possible given the pigeonhole principle etc.
The maximum number of repeats in the returned sample should be the
minimum number possible given what was requested.

Fix #13
