### PR TITLE
consolidate filter methods

### DIFF
--- a/braingeneers/analysis/analysis.py
+++ b/braingeneers/analysis/analysis.py
@@ -461,17 +461,16 @@ class SpikeData:
     @staticmethod
     def from_thresholding(data, fs_Hz=20e3, threshold_sigma=5.0,
                           filter_order=3, filter_lo_Hz=300.0,
-                          filter_hi_Hz=6e3, time_step_sec=10.0,
-                          do_filter=True, hysteresis=True,
-                          direction='both'):
+                          filter_hi_Hz=6e3, do_filter=True,
+                          hysteresis=True, direction='both'):
         """
         Create a SpikeData object from raw data by filtering and
         thresholding raw electrophysiological data formatted as an array
         with shape (channels, time).
         """
         if do_filter:
-            data = filter(data, fs_Hz, filter_order, filter_lo_Hz,
-                          filter_hi_Hz, time_step_sec)
+            data = butter_filter(data, filter_lo_Hz, filter_hi_Hz,
+                                 fs_Hz, filter_order)
 
         threshold = threshold_sigma * np.std(data, axis=1, keepdims=True)
 
@@ -1107,6 +1106,7 @@ def randomize_raster(raster, seed=None):
     return rsm
 
 
+@deprecated('Prefer analysis.butter_filter()', version='0.1.14')
 def filter(raw_data, fs_Hz=20000, filter_order=3, filter_lo_Hz=300,
            filter_hi_Hz=6000, time_step_size_s=10, channel_step_size=100,
            verbose=0, zi=None, return_zi=False):

--- a/braingeneers/analysis/analysis.py
+++ b/braingeneers/analysis/analysis.py
@@ -460,17 +460,18 @@ class SpikeData:
 
     @staticmethod
     def from_thresholding(data, fs_Hz=20e3, threshold_sigma=5.0,
-                          filter_order=3, filter_lo_Hz=300.0,
-                          filter_hi_Hz=6e3, do_filter=True,
+                          filter=dict(lowcut=300.0, highcut=6e3, order=3),
                           hysteresis=True, direction='both'):
         """
         Create a SpikeData object from raw data by filtering and
         thresholding raw electrophysiological data formatted as an array
         with shape (channels, time).
+
+        Filtering is done by butter_filter() with parameters given
+        by the `filter` argument. Set `filter` to None to disable.
         """
-        if do_filter:
-            data = butter_filter(data, filter_lo_Hz, filter_hi_Hz,
-                                 fs_Hz, filter_order)
+        if filter:
+            data = butter_filter(data, fs=fs_Hz, **filter)
 
         threshold = threshold_sigma * np.std(data, axis=1, keepdims=True)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 #   list is not duplicated. It is also necessary to allow the dependency list to be validated at runtime.
 setup(
     name='braingeneerspy',
-    version='0.1.13',
+    version='0.1.14',
     python_requires='>=3.10.0',  # needed for ordered dictionaries; also this bug in 3.9 and below https://bugs.python.org/issue42853
     description='Braingeneers Python utilities',
     long_description=long_description,


### PR DESCRIPTION
Relating to the discussion with @surygeng in #41, also attn: @ashsrobbins.

- Deprecate filter() for butter_filter()
- Simplify filtering SpikeData.from_thresholding()

The first commit here is just deprecating the more complicated filter method whose fancy features it doesn't look like are being used.

The second is breaking, so let's reject this if people are actually using this feature: the interface of the `SpikeData.from_thresholding()` constructor was overly complicated, with 4 different kwargs being used for the optional pre-filtering. This is now simplified by just having one parameter `filter` that gives the parameters for `butter_filter()`, and can be None to emulate the previous do_filter=False behavior.
