### PR TITLE
Update configure.py

### DIFF
--- a/braingeneers/utils/configure.py
+++ b/braingeneers/utils/configure.py
@@ -31,7 +31,7 @@ DEPENDENCIES = {
         # 'sortedcontainers',
         'boto3',
         'joblib>=1.3.0,<2',
-        'smart_open @ git+https://github.com/davidparks21/smart_open.git@develop',  # 'smart_open>=5.1.0',  the hash version fixes the bytes from-to range header issue.
+        'braingeneers_smart_open',  # 'smart_open>=5.1.0',  the hash version fixes the bytes from-to range header issue.
         'awswrangler==3.*',
     ],
     'data': [


### PR DESCRIPTION
This should fix the smart_open issue.

```
pip install git+https://github.com/DailyDreaming/braingeneerspy.git#egg=braingeneerspy[analysis,iot]
```

Current output from the reported issue in python3.10:

```
(venv) quokka@qcore 03:46 PM ~$ pip install git+https://github.com/braingeneers/braingeneerspy.git#egg=braingeneerspy[analysis,iot]
DEPRECATION: git+https://github.com/braingeneers/braingeneerspy.git#egg=braingeneerspy[analysis,iot] contains an egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/11617
Collecting braingeneerspy[analysis,iot]
  Cloning https://github.com/braingeneers/braingeneerspy.git to /tmp/pip-install-u18trwox/braingeneerspy_de75f19838394b368102b1d1be3fe15e
  Running command git clone --filter=blob:none --quiet https://github.com/braingeneers/braingeneerspy.git /tmp/pip-install-u18trwox/braingeneerspy_de75f19838394b368102b1d1be3fe15e
  Resolved https://github.com/braingeneers/braingeneerspy.git to commit 8c8b1f013996a12c3fa67ecfd6d6780a6437717d
  Preparing metadata (setup.py) ... done
Collecting smart_open@ git+https://github.com/davidparks21/smart_open.git@develop (from braingeneerspy[analysis,iot])
  Cloning https://github.com/davidparks21/smart_open.git (to revision develop) to /tmp/pip-install-u18trwox/smart-open_f939f87e4fb04384b216075cdb424e69
  Running command git clone --filter=blob:none --quiet https://github.com/davidparks21/smart_open.git /tmp/pip-install-u18trwox/smart-open_f939f87e4fb04384b216075cdb424e69
  remote: Repository 'davidparks21/smart_open' is disabled.
  remote: Please ask the owner to check their account.
  fatal: unable to access 'https://github.com/davidparks21/smart_open.git/': The requested URL returned error: 403
  error: subprocess-exited-with-error
  
  × git clone --filter=blob:none --quiet https://github.com/davidparks21/smart_open.git /tmp/pip-install-u18trwox/smart-open_f939f87e4fb04384b216075cdb424e69 did not run successfully.
  │ exit code: 128
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× git clone --filter=blob:none --quiet https://github.com/davidparks21/smart_open.git /tmp/pip-install-u18trwox/smart-open_f939f87e4fb04384b216075cdb424e69 did not run successfully.
│ exit code: 128
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip is available: 23.2.1 -> 23.3
[notice] To update, run: pip install --upgrade pip
(venv) quokka@qcore 03:47 PM ~$ pip install braingeneers_smart_open
Collecting braingeneers_smart_open
  Obtaining dependency information for braingeneers_smart_open from https://files.pythonhosted.org/packages/51/32/a12cf7a32dae5a47a7a6bb7bad93bb7b8af78e631b0d07aac6b17ef35ffd/braingeneers_smart_open-2023.10.6-py3-none-any.whl.metadata
  Downloading braingeneers_smart_open-2023.10.6-py3-none-any.whl.metadata (21 kB)
Downloading braingeneers_smart_open-2023.10.6-py3-none-any.whl (59 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 59.9/59.9 kB 3.4 MB/s eta 0:00:00
Installing collected packages: braingeneers_smart_open
Successfully installed braingeneers_smart_open-2023.10.6

[notice] A new release of pip is available: 23.2.1 -> 23.3
[notice] To update, run: pip install --upgrade pip
```