### PR TITLE
update load_gpio_maxwell

### DIFF
--- a/src/braingeneers/data/datasets_electrophysiology.py
+++ b/src/braingeneers/data/datasets_electrophysiology.py
@@ -5,7 +5,7 @@ import json
 import warnings
 import copy
 
-# import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt
 import numpy as np
 import shutil
 import h5py
@@ -287,11 +287,11 @@ def load_windows(metadata, exp, window_centers, window_sz, dtype=np.float16,
 
         # Check if window is out of bounds
         if window[0] < 0 or window[1] > dataset_length:
-            print("Window out of bounds, inserting zeros for window",window)
+            print("Window out of bounds, inserting zeros for window", window)
             try:
                 data_temp = np.zeros((data_temp.shape[0],window_sz),dtype=dtype)
             except Exception as e:
-                print(e)
+                print(e, file=sys.stderr)
                 data_temp = load_window(metadata, exp, window, dtype=dtype, channels=channels)
         else:
             data_temp = load_window(metadata, exp, window, dtype=dtype, channels=channels)
@@ -659,10 +659,10 @@ def load_stims_maxwell(uuid: str, metadata_ephys_exp: dict = None, experiment_st
         return df
         
     except FileNotFoundError:
-        print(f'\tThere seems to be no stim log file for this experiment! :(')
+        print(f'\tThere seems to be no stim log file for this experiment! :(', file=sys.stderr)
         return None
     except OSError:
-        print(f'\tThere seems to be no stim log file (on s3) for this experiment! :(')
+        print(f'\tThere seems to be no stim log file (on s3) for this experiment! :(', file=sys.stderr)
         return None
 
    
@@ -676,7 +676,7 @@ def load_gpio_maxwell(dataset_path, fs=20000.0):
     with smart_open.open(dataset_path, 'rb') as f:
         with h5py.File(f, 'r') as dataset:
             if 'bits' not in dataset.keys():
-                print('No GPIO event in the dataset!')
+                print('No GPIO event in the dataset!', file=sys.stderr)
                 return np.array([])
             bits_dataset = list(dataset['bits'])
             bits_dataframe = [bits_dataset[i][0] for i in range(len(bits_dataset))]
@@ -1230,7 +1230,7 @@ def _axion_generate_per_block_metadata(filename: str):
 
                 fid.seek(start + int(obj.length.item()), 0)
                 if fid.tell() != start + obj.length:
-                    print('Unexpected Channel array length')
+                    print('Unexpected Channel array length', file=sys.stderr)
 
             elif obj.type == 3:
                 continue

--- a/src/braingeneers/data/datasets_electrophysiology.py
+++ b/src/braingeneers/data/datasets_electrophysiology.py
@@ -5,7 +5,7 @@ import json
 import warnings
 import copy
 
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
 import numpy as np
 import shutil
 import h5py
@@ -666,7 +666,7 @@ def load_stims_maxwell(uuid: str, metadata_ephys_exp: dict = None, experiment_st
         return None
 
    
-def load_gpio_maxwell(dataset_path, fs=20000):
+def load_gpio_maxwell(dataset_path, fs=20000.0):
     """
     Loads the GPIO events for optogenetics stimulation.
     :param dataset_path: a local or a s3 path
@@ -675,10 +675,12 @@ def load_gpio_maxwell(dataset_path, fs=20000):
     """
     with smart_open.open(dataset_path, 'rb') as f:
         with h5py.File(f, 'r') as dataset:
-            assert 'bits' in dataset.keys(), 'No GPIO event in the dataset!'
+            if 'bits' not in dataset.keys():
+                print('No GPIO event in the dataset!')
+                return np.array([])
             bits_dataset = list(dataset['bits'])
-            bits_dataframe = [bits_dataset[i][0] for i in range(len(bits_dataset))]  
-            rec_startframe = dataset['raw'][-1, 0] << 16 | dataset['raw'][-2, 0]
+            bits_dataframe = [bits_dataset[i][0] for i in range(len(bits_dataset))]
+            rec_startframe = dataset['sig'][-1, 0] << 16 | dataset['sig'][-2, 0]
     if len(bits_dataframe) % 2 == 0:
         stim_pairs = (np.array(bits_dataframe) - rec_startframe).reshape(len(bits_dataframe) // 2, 2)
         return stim_pairs / fs

--- a/src/braingeneers/data/datasets_electrophysiology_test.py
+++ b/src/braingeneers/data/datasets_electrophysiology_test.py
@@ -124,6 +124,25 @@ class MaxwellReaderTests(unittest.TestCase):
 
         assert modified_metadata == expected_metadata
 
+    @skip_unittest_if_offline
+    def test_load_gpio_maxwell(self):
+        """ Read gpio event for Maxwell V1 file"""
+        data_1 = "s3://braingeneers/ephys/" \
+                 "2023-04-02-hc328_rec/original/data/" \
+                 "2023_04_02_hc328_0.raw.h5"
+        data_2 = "s3://braingeneers/ephys/" \
+                 "2023-04-04-e-hc328_hckcr1-2_040423_recs/original/data/" \
+                 "hc3.28_hckcr1_chip8787_plated4.4_rec4.4.raw.h5"
+        data_3 = "s3://braingeneers/ephys/" \
+                 "2023-04-04-e-hc328_hckcr1-2_040423_recs/original/data/" \
+                 "2023_04_04_hc328_hckcr1-2_3.raw.h5"
+        gpio_1 = ephys.load_gpio_maxwell(data_1)
+        gpio_2 = ephys.load_gpio_maxwell(data_2)
+        gpio_3 = ephys.load_gpio_maxwell(data_3)
+        self.assertEqual(gpio_1.shape, (1, 2))
+        self.assertEqual(gpio_2.shape, (0,))
+        self.assertEqual(gpio_3.shape, (29,))
+
 
 class MEArecReaderTests(unittest.TestCase):
     """The fake reader test."""


### PR DESCRIPTION
Modify load_gpio_maxwell function to output an empty array instead of assertion error when there is no gpio event found from the recording. This function works for maxwell v1 file. 