### PR TITLE
Reduce the number of extras.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]  # add this back later: , "3.12"
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false, false, true]
 
@@ -39,7 +39,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install package
-        run: python -m pip install .[test]
+        run: python -m pip install .[dev]
 
       - name: Test package
         run: >-

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,4 +15,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - docs
+        - dev

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install "braingeneers[ml]"
 - Install with Hengen lab dependencies:
 
 ```bash
-pip install "braingeneers[ml]"
+pip install "braingeneers[hengenlab]"
 ```
 
 - Install with developer dependencies (running tests and building sphinx docs):

--- a/README.md
+++ b/README.md
@@ -39,10 +39,22 @@ pip install --force-reinstall git+https://github.com/braingeneers/braingeneerspy
 
 You can install `braingeneerspy` with specific optional dependencies based on your needs. Use the following command examples:
 
-- Install with IoT, analysis, and data access functions (skips machine learning and lab-specific dependencies):
+- Install with machine-learning dependencies:
 
 ```bash
-pip install "braingeneers[iot,analysis,data]"
+pip install "braingeneers[ml]"
+```
+
+- Install with Hengen lab dependencies:
+
+```bash
+pip install "braingeneers[ml]"
+```
+
+- Install with developer dependencies (running tests and building sphinx docs):
+
+```bash
+pip install "braingeneers[dev]"
 ```
 
 - Install with all optional dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     'schedule',
     'scipy>=1.10.0',
     'tenacity',
-    "typing_extensions>=4.6; python_version<3.11"
+    "typing_extensions>=4.6; python_version<'3.11'"
 ]
 
 [tool.hatch.build.hooks.vcs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "braingeneers"
-authors = ["UCSC Braingeneers"]
+authors = [
+  { name = "UCSC Braingeneers", email = "ucscgi@ucsc.edu" },
+]
 maintainers = [
   { name = "David", email = "dfparks@ucsc.edu" },
   { name = "Alex", email = "atspaeth@ucsc.edu" },
@@ -46,7 +48,7 @@ dependencies = [
     'schedule',
     'scipy>=1.10.0',
     'tenacity',
-    "typing_extensions >=4.6; python_version<'3.11'"
+    "typing_extensions>=4.6; python_version<3.11"
 ]
 
 [tool.hatch.build.hooks.vcs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "braingeneers"
-authors = [
-  { name = "Braingeneers", email = "me@example.com" },
+authors = ["UCSC Braingeneers"]
+maintainers = [
+  { name = "David", email = "dfparks@ucsc.edu" },
+  { name = "Alex", email = "atspaeth@ucsc.edu" },
+  { name = "Lon", email = "lblauvel@ucsc.edu" },
 ]
 description = "Braingeneers Python utilities"
 readme = "README.md"
@@ -27,12 +30,23 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "typing_extensions >=4.6; python_version<'3.11'",
-  'deprecated',
-  'requests',
-  'numpy',
-  'tenacity',
-  'boto3',
+    'awswrangler==3.*',
+    'boto3',
+    'braingeneers-smart-open==2023.10.6',
+    'deprecated',
+    'h5py',
+    'matplotlib',
+    'nptyping',
+    'numpy',
+    'paho-mqtt',
+    'pandas',
+    'powerlaw',
+    'redis',
+    'requests',
+    'schedule',
+    'scipy>=1.10.0',
+    'tenacity',
+    "typing_extensions >=4.6; python_version<'3.11'"
 ]
 
 [tool.hatch.build.hooks.vcs]
@@ -43,35 +57,9 @@ local_scheme = "no-local-version"
 
 [project.optional-dependencies]
 all = [
-  'braingeneers[data]',
-  'braingeneers[analysis]',
   'braingeneers[ml]',
-  'braingeneers[iot]',
   'braingeneers[hengenlab]',
-  'braingeneers[test]',
-  'braingeneers[docs]',
-]
-data = [
-  'h5py',
-  'braingeneers-smart-open==2023.10.6',  # 'smart_open>=5.1.0',  the hash version fixes the bytes from-to range header issue.
-  'awswrangler==3.*',
-  'pandas',
-  'nptyping',
-  'paho-mqtt'
-]
-iot = [
-  'redis',
-  'schedule',
-  'paho-mqtt'
-]
-analysis = [
-  'scipy>=1.10.0',
-  'pandas',
-  'powerlaw',
-  'matplotlib',
-  # Both of these dependencies are required for read_phy_files
-  'awswrangler==3.*',
-  'braingeneers-smart-open==2023.10.6',  # 'smart_open>=5.1.0',  the hash version fixes the bytes from-to range header issue.
+  'braingeneers[dev]',
 ]
 ml = [
   'torch',
@@ -80,11 +68,9 @@ ml = [
 hengenlab = [
   'neuraltoolkit==0.3.1',  # channel mapping information
 ]
-test = [
+dev = [
   "pytest >=6",
   "pytest-cov >=3",
-]
-docs = [
   "sphinx>=4.0",
   "myst_parser>=0.13",
   "sphinx_book_theme>=0.1.0",


### PR DESCRIPTION
Mostly wanted to open this up for discussion, since I think it would simplify things a little.

Proposing we include all extra dependencies in the `pip install braingeneers` install by default, and only separate:

- `ml` (large and time-consuming install)
-  `hengenlab` (not as well-maintained/reliable, because it's a personal lab's python library)
- `dev` (all test and documentation dependencies)

Also: added the maintainers section and got rid of the bogus boilerplate email address for the author section.