### PR TITLE
Added iot.messaging.get|set_metadata_for_stream functions

### DIFF
--- a/src/braingeneers/iot/messaging.py
+++ b/src/braingeneers/iot/messaging.py
@@ -473,6 +473,76 @@ class MessageBroker:
         topic_regex = _mqtt_topic_regex(topic)
         del self._subscribed_message_callback_map[topic_regex]
 
+    @staticmethod
+    def _stream_metadata_key(stream_name: str) -> str:
+        return f'_metadata_{stream_name}'
+
+    def set_metadata_for_stream(self, stream_name: str, metadata: dict) -> None:
+        """
+        Set metadata associated with a data stream.
+
+        This function stores a JSON-serializable dictionary as metadata for the given
+        stream name. The metadata is stored as a single Redis key and will overwrite
+        any previously stored metadata for that stream.
+
+        This is intended to hold descriptive or configuration information about a stream,
+        such as experiment parameters, schema definitions, or other contextual data that
+        applies to the entire stream rather than individual entries.
+
+        Relationship to data streams:
+            - This metadata is NOT part of the Redis stream created by
+            publish_data_stream(), and is not returned by subscribe_data_stream()
+            or poll_data_streams().
+            - Data streams (via XADD/XREAD) are append-only logs of time-series data.
+            - Metadata stored here is a separate key-value store intended for static
+            or infrequently changing information about the stream.
+
+        Example usage:
+            mb.set_metadata_for_stream(
+                "ephys/experiment_123",
+                {"sample_rate": 25000, "channels": 32}
+            )
+
+        :param stream_name: Name of the data stream.
+        :param metadata: A JSON-serializable dictionary of metadata.
+        """
+        if not isinstance(metadata, dict):
+            raise TypeError('metadata must be a dictionary.')
+
+        self.redis_client.set(
+            self._stream_metadata_key(stream_name), json.dumps(metadata)
+        )
+
+    def get_metadata_for_stream(self, stream_name: str) -> dict:
+        """
+        Retrieve metadata associated with a data stream.
+
+        Returns the metadata dictionary previously stored with
+        set_metadata_for_stream(). If no metadata exists for the given stream,
+        an empty dictionary is returned.
+
+        Relationship to data streams:
+            - This function does NOT read from the Redis stream used by
+            publish_data_stream().
+            - It only retrieves metadata stored separately from the stream data.
+            - Use this in conjunction with subscribe_data_stream() or
+            poll_data_streams() to obtain both the stream data and its
+            associated metadata.
+
+        Example usage:
+            metadata = mb.get_metadata_for_stream("ephys/experiment_123")
+            sample_rate = metadata.get("sample_rate")
+
+        :param stream_name: Name of the data stream.
+        :return: A dictionary containing the stored metadata, or {} if none exists.
+        """
+        value = self.redis_client.get(self._stream_metadata_key(stream_name))
+        if value is None:
+            return {}
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
+        return json.loads(value)
+
     def publish_data_stream(self, stream_name: str, data: Dict[Union[str, bytes], bytes], stream_size: int) -> None:
         """
         Publish (potentially large) data to a stream.

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -449,6 +449,57 @@ port = 1883
             self.assertIsNone(self.broker._mqtt_connection)
 
 
+class FakeRedisMetadataStore:
+    def __init__(self):
+        self.data = {}
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def get(self, key):
+        value = self.data.get(key)
+        return None if value is None else value.encode("utf-8")
+
+
+class TestStreamMetadata(unittest.TestCase):
+    def setUp(self):
+        self.broker = messaging.MessageBroker.__new__(messaging.MessageBroker)
+        self.broker._redis_client = FakeRedisMetadataStore()
+
+    def test_set_and_get_stream_metadata_round_trip(self):
+        metadata = {"sample_rate": 25000, "channels": 32}
+
+        self.broker.set_metadata_for_stream("ephys/experiment_123", metadata)
+
+        self.assertEqual(
+            self.broker.get_metadata_for_stream("ephys/experiment_123"), metadata
+        )
+
+    def test_set_stream_metadata_overwrites_existing_value(self):
+        self.broker.set_metadata_for_stream(
+            "ephys/experiment_123", {"sample_rate": 20000}
+        )
+        self.broker.set_metadata_for_stream(
+            "ephys/experiment_123", {"sample_rate": 25000}
+        )
+
+        self.assertEqual(
+            self.broker.get_metadata_for_stream("ephys/experiment_123"),
+            {"sample_rate": 25000},
+        )
+
+    def test_get_stream_metadata_returns_empty_dict_when_missing(self):
+        self.assertEqual(
+            self.broker.get_metadata_for_stream("ephys/missing_experiment"), {}
+        )
+
+    def test_set_stream_metadata_requires_dict(self):
+        with self.assertRaises(TypeError):
+            self.broker.set_metadata_for_stream(
+                "ephys/experiment_123", ["not", "a", "dict"]
+            )
+
+
 class TestInterprocessQueue(unittest.TestCase):
     def setUp(self) -> None:
         self.mb = _make_message_broker()


### PR DESCRIPTION
# Add Redis-backed stream metadata helpers and tests

  ## Summary

  This PR adds a small metadata API to MessageBroker for Redis streams:

  - set_metadata_for_stream(stream_name, metadata)
  - get_metadata_for_stream(stream_name)

  The metadata is stored separately from the Redis stream itself, so it can hold stream-level context such as schema,
  sample rate, channel count, or experiment configuration without being mixed into the append-only stream payloads.

  ## Changes

  - Added MessageBroker._stream_metadata_key() to centralize Redis key generation.
  - Added MessageBroker.set_metadata_for_stream() to store JSON-serializable stream metadata.
  - Added MessageBroker.get_metadata_for_stream() to retrieve stored metadata, returning {} when none exists.
  - Enforced that metadata passed to set_metadata_for_stream() must be a dict.
  - Added targeted unit tests for:
      - metadata round-trip
      - overwrite behavior
      - missing metadata returning {}
      - invalid non-dict input raising TypeError

  ## Notes

  - Stream metadata is stored outside the Redis stream used by publish_data_stream() / poll_data_streams().
  - This preserves the current stream data model while adding a simple place for stream-level annotations.

  ## Testing

  Ran:

  python -m unittest tests.test_messaging.TestStreamMetadata

  Result: passed.
